### PR TITLE
fix(NET-10): Pass request URLs per call instead of mutating shared BaseUrl

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,6 +26,13 @@ jobs:
         with:
           submodules: true
 
+      - name: Check for shared mutable BaseUrl
+        run: |
+          if grep -rn "BaseUrl =" OpenPayments.Sdk/Clients/; then
+            echo "::error::Writes to BaseUrl in OpenPayments.Sdk/Clients/ reintroduce the singleton race from issue #16. Pass the target URL per call instead."
+            exit 1
+          fi
+
       - name: Setup .NET 9.0 SDK
         uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,8 +28,16 @@ jobs:
 
       - name: Check for shared mutable BaseUrl
         run: |
-          if grep -rn "BaseUrl =" OpenPayments.Sdk/Clients/; then
-            echo "::error::Writes to BaseUrl in OpenPayments.Sdk/Clients/ reintroduce the singleton race from issue #16. Pass the target URL per call instead."
+          set -e
+          scanned_count=$(find OpenPayments.Sdk/ -name '*.cs' ! -name '*.g.cs' 2>/dev/null | wc -l)
+          if [ "$scanned_count" -eq 0 ]; then
+            echo "::error::No non-generated .cs files found under OpenPayments.Sdk/ to scan for BaseUrl writes. Did the directory move or get renamed? Update this guard's path so it can't silently pass."
+            exit 1
+          fi
+          matches=$(grep -rnE "BaseUrl[[:space:]]*=" --include='*.cs' --exclude='*.g.cs' OpenPayments.Sdk/ || true)
+          if [ -n "$matches" ]; then
+            echo "$matches"
+            echo "::error::Writes to BaseUrl outside generated code reintroduce the singleton race from issue #16. Pass the target URL per call instead."
             exit 1
           fi
 

--- a/OpenPayments.Sdk.Tests/Clients/AuthenticatedClient_Fixture.cs
+++ b/OpenPayments.Sdk.Tests/Clients/AuthenticatedClient_Fixture.cs
@@ -238,6 +238,18 @@ public class AuthenticatedClientFixture
         ],
     };
 
+    public ListIncomingPaymentsResponse ListIncomingPaymentsResponse = new()
+    {
+        Pagination = new PageInfo
+        {
+            StartCursor = "1234",
+            EndCursor = "1234",
+            HasNextPage = false,
+            HasPreviousPage = false,
+        },
+        Result = [],
+    };
+
     public HttpClient CreateHttpClientMock(
         object? responseObject = null,
         HttpStatusCode? code = null

--- a/OpenPayments.Sdk.Tests/Clients/AuthenticatedClient_Fixture.cs
+++ b/OpenPayments.Sdk.Tests/Clients/AuthenticatedClient_Fixture.cs
@@ -271,4 +271,18 @@ public class AuthenticatedClientFixture
 
         return new HttpClient(handler.Object) { BaseAddress = new Uri(BaseUrl) };
     }
+
+    /// <summary>
+    /// Builds a client whose handler records request URIs. Deliberately leaves
+    /// <see cref="HttpClient.BaseAddress"/> unset: every SDK request must carry an absolute URI,
+    /// and a relative one should fail loudly rather than be silently resolved.
+    /// </summary>
+    public (HttpClient Client, RecordingHandler Handler) CreateRecordingHttpClient(
+        object? responseObject = null,
+        HttpStatusCode? code = null
+    )
+    {
+        var handler = new RecordingHandler(responseObject, code);
+        return (new HttpClient(handler), handler);
+    }
 }

--- a/OpenPayments.Sdk.Tests/Clients/AuthenticatedClient_RequestUrl_Tests.cs
+++ b/OpenPayments.Sdk.Tests/Clients/AuthenticatedClient_RequestUrl_Tests.cs
@@ -1,0 +1,30 @@
+using FluentAssertions;
+using OpenPayments.Sdk.Clients;
+
+namespace OpenPayments.Sdk.Tests.Clients;
+
+[Collection("AuthenticatedClient")]
+public class AuthenticatedClient_RequestUrl_Tests(AuthenticatedClientFixture fixture)
+{
+    private readonly AuthenticatedClientFixture _fixture = fixture;
+
+    private AuthenticatedClient CreateClient(HttpClient http) =>
+        new(http, _fixture.PrivateKey, _fixture.KeyId, _fixture.ClientUrl);
+
+    [Fact]
+    public async Task RotateTokenAsync_RequestsTheTokenUrlVerbatim()
+    {
+        var (http, handler) = _fixture.CreateRecordingHttpClient(_fixture.TokenResponse);
+        var client = CreateClient(http);
+
+        await client.RotateTokenAsync(
+            new AuthRequestArgs
+            {
+                Url = new Uri("https://auth-a.example/token/abc"),
+                AccessToken = "token",
+            }
+        );
+
+        handler.LastRequestUri.AbsoluteUri.Should().Be("https://auth-a.example/token/abc");
+    }
+}

--- a/OpenPayments.Sdk.Tests/Clients/AuthenticatedClient_RequestUrl_Tests.cs
+++ b/OpenPayments.Sdk.Tests/Clients/AuthenticatedClient_RequestUrl_Tests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using OpenPayments.Sdk.Clients;
+using OpenPayments.Sdk.Generated.Resource;
 
 namespace OpenPayments.Sdk.Tests.Clients;
 
@@ -26,5 +27,116 @@ public class AuthenticatedClient_RequestUrl_Tests(AuthenticatedClientFixture fix
         );
 
         handler.LastRequestUri.AbsoluteUri.Should().Be("https://auth-a.example/token/abc");
+    }
+
+    [Fact]
+    public async Task CreateIncomingPaymentAsync_AppendsIncomingPaymentsToTheResourceServer()
+    {
+        var (http, handler) = _fixture.CreateRecordingHttpClient(
+            _fixture.CreateIncomingPaymentResponse,
+            System.Net.HttpStatusCode.Created
+        );
+        var client = CreateClient(http);
+
+        await client.CreateIncomingPaymentAsync(
+            new AuthRequestArgs
+            {
+                Url = new Uri("https://host-a.example"),
+                AccessToken = "token",
+            },
+            _fixture.CreateIncomingPaymentBody
+        );
+
+        handler
+            .LastRequestUri.AbsoluteUri.Should()
+            .Be("https://host-a.example/incoming-payments");
+    }
+
+    [Fact]
+    public async Task CreateIncomingPaymentAsync_DoesNotDoubleSlashWhenResourceServerHasTrailingSlash()
+    {
+        var (http, handler) = _fixture.CreateRecordingHttpClient(
+            _fixture.CreateIncomingPaymentResponse,
+            System.Net.HttpStatusCode.Created
+        );
+        var client = CreateClient(http);
+
+        await client.CreateIncomingPaymentAsync(
+            new AuthRequestArgs
+            {
+                Url = new Uri("https://host-a.example/resource/"),
+                AccessToken = "token",
+            },
+            _fixture.CreateIncomingPaymentBody
+        );
+
+        handler
+            .LastRequestUri.AbsoluteUri.Should()
+            .Be("https://host-a.example/resource/incoming-payments");
+    }
+
+    [Fact]
+    public async Task GetIncomingPaymentAsync_RequestsTheResourceUrlVerbatim()
+    {
+        var (http, handler) = _fixture.CreateRecordingHttpClient(
+            _fixture.CreateIncomingPaymentResponse
+        );
+        var client = CreateClient(http);
+
+        await client.GetIncomingPaymentAsync(
+            new AuthRequestArgs
+            {
+                Url = new Uri("https://host-a.example/incoming-payments/1"),
+                AccessToken = "token",
+            }
+        );
+
+        handler
+            .LastRequestUri.AbsoluteUri.Should()
+            .Be("https://host-a.example/incoming-payments/1");
+    }
+
+    [Fact]
+    public async Task CompleteIncomingPaymentsAsync_AppendsASingleCompleteSegment()
+    {
+        var (http, handler) = _fixture.CreateRecordingHttpClient(
+            _fixture.CreateIncomingPaymentResponse
+        );
+        var client = CreateClient(http);
+
+        await client.CompleteIncomingPaymentsAsync(
+            new AuthRequestArgs
+            {
+                Url = new Uri("https://host-a.example/incoming-payments/1"),
+                AccessToken = "token",
+            }
+        );
+
+        handler
+            .LastRequestUri.AbsoluteUri.Should()
+            .Be("https://host-a.example/incoming-payments/1/complete");
+    }
+
+    [Fact]
+    public async Task ListIncomingPaymentsAsync_AppendsIncomingPaymentsToTheResourceServer()
+    {
+        var (http, handler) = _fixture.CreateRecordingHttpClient(
+            _fixture.ListIncomingPaymentsResponse
+        );
+        var client = CreateClient(http);
+
+        await client.ListIncomingPaymentsAsync(
+            new AuthRequestArgs
+            {
+                Url = new Uri("https://host-a.example"),
+                AccessToken = "token",
+            },
+            new ListIncomingPaymentQuery { WalletAddress = "https://host-a.example/wallet/1" }
+        );
+
+        handler
+            .LastRequestUri.GetLeftPart(UriPartial.Path)
+            .Should()
+            .Be("https://host-a.example/incoming-payments");
     }
 }

--- a/OpenPayments.Sdk.Tests/Clients/AuthenticatedClient_RequestUrl_Tests.cs
+++ b/OpenPayments.Sdk.Tests/Clients/AuthenticatedClient_RequestUrl_Tests.cs
@@ -178,4 +178,71 @@ public class AuthenticatedClient_RequestUrl_Tests(AuthenticatedClientFixture fix
 
         handler.LastRequestUri.AbsoluteUri.Should().Be("https://host-a.example/quotes/1");
     }
+
+    [Fact]
+    public async Task CreateOutgoingPaymentAsync_AppendsOutgoingPaymentsToTheResourceServer()
+    {
+        var (http, handler) = _fixture.CreateRecordingHttpClient(
+            _fixture.CreateOutgoingPaymentResponse,
+            HttpStatusCode.Created
+        );
+        var client = CreateClient(http);
+
+        await client.CreateOutgoingPaymentAsync(
+            new AuthRequestArgs
+            {
+                Url = new Uri("https://host-a.example"),
+                AccessToken = "token",
+            },
+            _fixture.CreateOutgoingPaymentBodyFromQuote
+        );
+
+        handler
+            .LastRequestUri.AbsoluteUri.Should()
+            .Be("https://host-a.example/outgoing-payments");
+    }
+
+    [Fact]
+    public async Task GetOutgoingPaymentAsync_RequestsTheResourceUrlVerbatim()
+    {
+        var (http, handler) = _fixture.CreateRecordingHttpClient(
+            _fixture.GetOutgoingPaymentResponse
+        );
+        var client = CreateClient(http);
+
+        await client.GetOutgoingPaymentAsync(
+            new AuthRequestArgs
+            {
+                Url = new Uri("https://host-a.example/outgoing-payments/1"),
+                AccessToken = "token",
+            }
+        );
+
+        handler
+            .LastRequestUri.AbsoluteUri.Should()
+            .Be("https://host-a.example/outgoing-payments/1");
+    }
+
+    [Fact]
+    public async Task ListOutgoingPaymentsAsync_AppendsOutgoingPaymentsToTheResourceServer()
+    {
+        var (http, handler) = _fixture.CreateRecordingHttpClient(
+            _fixture.ListOutgoingPaymentsResponse
+        );
+        var client = CreateClient(http);
+
+        await client.ListOutgoingPaymentsAsync(
+            new AuthRequestArgs
+            {
+                Url = new Uri("https://host-a.example"),
+                AccessToken = "token",
+            },
+            new ListOutgoingPaymentQuery { WalletAddress = "https://host-a.example/wallet/1" }
+        );
+
+        handler
+            .LastRequestUri.GetLeftPart(UriPartial.Path)
+            .Should()
+            .Be("https://host-a.example/outgoing-payments");
+    }
 }

--- a/OpenPayments.Sdk.Tests/Clients/AuthenticatedClient_RequestUrl_Tests.cs
+++ b/OpenPayments.Sdk.Tests/Clients/AuthenticatedClient_RequestUrl_Tests.cs
@@ -139,4 +139,42 @@ public class AuthenticatedClient_RequestUrl_Tests(AuthenticatedClientFixture fix
             .Should()
             .Be("https://host-a.example/incoming-payments");
     }
+
+    [Fact]
+    public async Task CreateQuoteAsync_AppendsQuotesToTheResourceServer()
+    {
+        var (http, handler) = _fixture.CreateRecordingHttpClient(
+            _fixture.CreateQuoteResponse,
+            System.Net.HttpStatusCode.Created
+        );
+        var client = CreateClient(http);
+
+        await client.CreateQuoteAsync(
+            new AuthRequestArgs
+            {
+                Url = new Uri("https://host-a.example"),
+                AccessToken = "token",
+            },
+            _fixture.CreateQuoteBody
+        );
+
+        handler.LastRequestUri.AbsoluteUri.Should().Be("https://host-a.example/quotes");
+    }
+
+    [Fact]
+    public async Task GetQuoteAsync_RequestsTheResourceUrlVerbatim()
+    {
+        var (http, handler) = _fixture.CreateRecordingHttpClient(_fixture.CreateQuoteResponse);
+        var client = CreateClient(http);
+
+        await client.GetQuoteAsync(
+            new AuthRequestArgs
+            {
+                Url = new Uri("https://host-a.example/quotes/1"),
+                AccessToken = "token",
+            }
+        );
+
+        handler.LastRequestUri.AbsoluteUri.Should().Be("https://host-a.example/quotes/1");
+    }
 }

--- a/OpenPayments.Sdk.Tests/Clients/AuthenticatedClient_RequestUrl_Tests.cs
+++ b/OpenPayments.Sdk.Tests/Clients/AuthenticatedClient_RequestUrl_Tests.cs
@@ -245,4 +245,18 @@ public class AuthenticatedClient_RequestUrl_Tests(AuthenticatedClientFixture fix
             .Should()
             .Be("https://host-a.example/outgoing-payments");
     }
+
+    [Fact]
+    public async Task RequestGrantAsync_RequestsThePathfulAuthServerUrlVerbatim()
+    {
+        var (http, handler) = _fixture.CreateRecordingHttpClient(_fixture.ApprovedGrantResponse);
+        var client = CreateClient(http);
+
+        await client.RequestGrantAsync(
+            new RequestArgs { Url = new Uri("https://auth-a.example/gnap") },
+            _fixture.RequestGrantBody
+        );
+
+        handler.LastRequestUri.AbsoluteUri.Should().Be("https://auth-a.example/gnap");
+    }
 }

--- a/OpenPayments.Sdk.Tests/Clients/AuthenticatedClient_RequestUrl_Tests.cs
+++ b/OpenPayments.Sdk.Tests/Clients/AuthenticatedClient_RequestUrl_Tests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using FluentAssertions;
 using OpenPayments.Sdk.Clients;
 using OpenPayments.Sdk.Generated.Resource;
@@ -34,7 +35,7 @@ public class AuthenticatedClient_RequestUrl_Tests(AuthenticatedClientFixture fix
     {
         var (http, handler) = _fixture.CreateRecordingHttpClient(
             _fixture.CreateIncomingPaymentResponse,
-            System.Net.HttpStatusCode.Created
+            HttpStatusCode.Created
         );
         var client = CreateClient(http);
 
@@ -57,7 +58,7 @@ public class AuthenticatedClient_RequestUrl_Tests(AuthenticatedClientFixture fix
     {
         var (http, handler) = _fixture.CreateRecordingHttpClient(
             _fixture.CreateIncomingPaymentResponse,
-            System.Net.HttpStatusCode.Created
+            HttpStatusCode.Created
         );
         var client = CreateClient(http);
 
@@ -145,7 +146,7 @@ public class AuthenticatedClient_RequestUrl_Tests(AuthenticatedClientFixture fix
     {
         var (http, handler) = _fixture.CreateRecordingHttpClient(
             _fixture.CreateQuoteResponse,
-            System.Net.HttpStatusCode.Created
+            HttpStatusCode.Created
         );
         var client = CreateClient(http);
 

--- a/OpenPayments.Sdk.Tests/Clients/AuthenticatedClient_RequestUrl_Tests.cs
+++ b/OpenPayments.Sdk.Tests/Clients/AuthenticatedClient_RequestUrl_Tests.cs
@@ -259,4 +259,95 @@ public class AuthenticatedClient_RequestUrl_Tests(AuthenticatedClientFixture fix
 
         handler.LastRequestUri.AbsoluteUri.Should().Be("https://auth-a.example/gnap");
     }
+
+    [Fact]
+    public async Task GetIncomingPaymentAsync_SequentialCallsAcrossHosts_EachReachesItsOwnHost()
+    {
+        var (http, handler) = _fixture.CreateRecordingHttpClient(
+            _fixture.CreateIncomingPaymentResponse
+        );
+        var client = CreateClient(http);
+
+        await client.GetIncomingPaymentAsync(
+            new AuthRequestArgs
+            {
+                Url = new Uri("https://host-a.example/incoming-payments/1"),
+                AccessToken = "token",
+            }
+        );
+        await client.GetIncomingPaymentAsync(
+            new AuthRequestArgs
+            {
+                Url = new Uri("https://host-b.example/incoming-payments/2"),
+                AccessToken = "token",
+            }
+        );
+
+        handler
+            .RequestUris.Select(u => u.AbsoluteUri)
+            .Should()
+            .Equal(
+                "https://host-a.example/incoming-payments/1",
+                "https://host-b.example/incoming-payments/2"
+            );
+    }
+
+    [Fact]
+    public async Task GetIncomingPaymentAsync_ParallelCallsAcrossHosts_EachReachesItsOwnHost()
+    {
+        var (http, handler) = _fixture.CreateRecordingHttpClient(
+            _fixture.CreateIncomingPaymentResponse
+        );
+        var client = CreateClient(http);
+
+        var targets = Enumerable
+            .Range(0, 200)
+            .Select(i => new Uri($"https://host-{i % 2}.example/incoming-payments/{i}"))
+            .ToArray();
+
+        await Parallel.ForEachAsync(
+            targets,
+            async (target, ct) =>
+            {
+                await client.GetIncomingPaymentAsync(
+                    new AuthRequestArgs { Url = target, AccessToken = "token" },
+                    ct
+                );
+            }
+        );
+
+        handler
+            .RequestUris.Select(u => u.AbsoluteUri)
+            .Should()
+            .BeEquivalentTo(targets.Select(t => t.AbsoluteUri));
+    }
+
+    [Fact]
+    public async Task RequestGrantAsync_ParallelCallsAcrossAuthServers_EachReachesItsOwnHost()
+    {
+        var (http, handler) = _fixture.CreateRecordingHttpClient(_fixture.ApprovedGrantResponse);
+        var client = CreateClient(http);
+
+        var targets = Enumerable
+            .Range(0, 200)
+            .Select(i => new Uri($"https://auth-{i % 2}.example/gnap/{i}"))
+            .ToArray();
+
+        await Parallel.ForEachAsync(
+            targets,
+            async (target, ct) =>
+            {
+                await client.RequestGrantAsync(
+                    new RequestArgs { Url = target },
+                    _fixture.RequestGrantBody,
+                    ct
+                );
+            }
+        );
+
+        handler
+            .RequestUris.Select(u => u.AbsoluteUri)
+            .Should()
+            .BeEquivalentTo(targets.Select(t => t.AbsoluteUri));
+    }
 }

--- a/OpenPayments.Sdk.Tests/Clients/RecordingHandler.cs
+++ b/OpenPayments.Sdk.Tests/Clients/RecordingHandler.cs
@@ -1,0 +1,59 @@
+using System.Net;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace OpenPayments.Sdk.Tests.Clients;
+
+/// <summary>
+/// Records the absolute URI of every request and returns a freshly built canned response.
+/// A new response per call matters: the parallel tests read each response body, and a shared
+/// instance would have its content stream consumed by the first reader.
+/// </summary>
+public sealed class RecordingHandler(object? responseObject = null, HttpStatusCode? statusCode = null)
+    : HttpMessageHandler
+{
+    private readonly List<Uri> _requestUris = [];
+    private readonly Lock _gate = new();
+
+    private readonly HttpStatusCode _statusCode =
+        statusCode ?? (responseObject == null ? HttpStatusCode.NoContent : HttpStatusCode.OK);
+
+    public IReadOnlyList<Uri> RequestUris
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return [.. _requestUris];
+            }
+        }
+    }
+
+    public Uri LastRequestUri => RequestUris[^1];
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken
+    )
+    {
+        lock (_gate)
+        {
+            _requestUris.Add(request.RequestUri!);
+        }
+
+        return Task.FromResult(
+            new HttpResponseMessage
+            {
+                StatusCode = _statusCode,
+                Content =
+                    responseObject == null
+                        ? new StringContent("", Encoding.UTF8)
+                        : new StringContent(
+                            JsonConvert.SerializeObject(responseObject),
+                            Encoding.UTF8,
+                            "application/json"
+                        ),
+            }
+        );
+    }
+}

--- a/OpenPayments.Sdk/Clients/AuthClientBase.cs
+++ b/OpenPayments.Sdk/Clients/AuthClientBase.cs
@@ -23,10 +23,11 @@ public class AuthClientBase : IAuthClientBase
         CancellationToken cancellationToken = default
     )
     {
-        _client.BaseUrl = requestArgs.Url.ToString();
         body.Client = _client.ClientUrl;
 
-        return await _client.CreateGrantAsync(body, cancellationToken).ConfigureAwait(false);
+        return await _client
+            .CreateGrantAsync(requestArgs.Url, body, cancellationToken)
+            .ConfigureAwait(false);
     }
 
     public async Task<AuthResponse> ContinueGrantAsync(

--- a/OpenPayments.Sdk/Clients/ResourceClientBase.cs
+++ b/OpenPayments.Sdk/Clients/ResourceClientBase.cs
@@ -22,9 +22,12 @@ public class ResourceClientBase : IResourceClientBase
         CancellationToken cancellationToken = default
     )
     {
-        _client.BaseUrl = requestArgs.Url.ToString();
-
-        return _client.PostIncomingPaymentAsync(body, requestArgs.AccessToken, cancellationToken);
+        return _client.PostIncomingPaymentAsync(
+            requestArgs.Url,
+            body,
+            requestArgs.AccessToken,
+            cancellationToken
+        );
     }
 
     public Task<IncomingPaymentResponse> GetIncomingPaymentAsync(
@@ -32,9 +35,11 @@ public class ResourceClientBase : IResourceClientBase
         CancellationToken cancellationToken = default
     )
     {
-        _client.BaseUrl = requestArgs.Url.ToString();
-
-        return _client.GetIncomingPaymentAsync(requestArgs.AccessToken, cancellationToken);
+        return _client.GetIncomingPaymentAsync(
+            requestArgs.Url,
+            requestArgs.AccessToken,
+            cancellationToken
+        );
     }
 
     public Task<IncomingPaymentResponse> CompleteIncomingPaymentAsync(
@@ -42,9 +47,11 @@ public class ResourceClientBase : IResourceClientBase
         CancellationToken cancellationToken = default
     )
     {
-        _client.BaseUrl = requestArgs.Url.ToString();
-
-        return _client.CompleteIncomingPaymentAsync(requestArgs.AccessToken, cancellationToken);
+        return _client.CompleteIncomingPaymentAsync(
+            requestArgs.Url,
+            requestArgs.AccessToken,
+            cancellationToken
+        );
     }
 
     public Task<ListIncomingPaymentsResponse> ListIncomingPaymentsAsync(
@@ -53,9 +60,8 @@ public class ResourceClientBase : IResourceClientBase
         CancellationToken cancellationToken = default
     )
     {
-        _client.BaseUrl = requestArgs.Url.ToString();
-
         return _client.ListIncomingPaymentsAsync(
+            requestArgs.Url,
             requestArgs.AccessToken,
             query.WalletAddress,
             query.Cursor,

--- a/OpenPayments.Sdk/Clients/ResourceClientBase.cs
+++ b/OpenPayments.Sdk/Clients/ResourceClientBase.cs
@@ -99,9 +99,12 @@ public class ResourceClientBase : IResourceClientBase
         CancellationToken cancellationToken = default
     )
     {
-        _client.BaseUrl = requestArgs.Url.ToString();
-
-        return _client.PostOutgoingPaymentAsync(body, requestArgs.AccessToken, cancellationToken);
+        return _client.PostOutgoingPaymentAsync(
+            requestArgs.Url,
+            body,
+            requestArgs.AccessToken,
+            cancellationToken
+        );
     }
 
     public Task<OutgoingPaymentResponse> GetOutgoingPaymentAsync(
@@ -109,9 +112,11 @@ public class ResourceClientBase : IResourceClientBase
         CancellationToken cancellationToken = default
     )
     {
-        _client.BaseUrl = requestArgs.Url.ToString();
-
-        return _client.GetOutgoingPaymentAsync(requestArgs.AccessToken, cancellationToken);
+        return _client.GetOutgoingPaymentAsync(
+            requestArgs.Url,
+            requestArgs.AccessToken,
+            cancellationToken
+        );
     }
 
     public Task<ListOutgoingPaymentsResponse> ListOutgoingPaymentAsync(
@@ -120,9 +125,8 @@ public class ResourceClientBase : IResourceClientBase
         CancellationToken cancellationToken = default
     )
     {
-        _client.BaseUrl = requestArgs.Url.ToString();
-
         return _client.ListOutgoingPaymentsAsync(
+            requestArgs.Url,
             requestArgs.AccessToken,
             query.WalletAddress,
             query.Cursor,

--- a/OpenPayments.Sdk/Clients/ResourceClientBase.cs
+++ b/OpenPayments.Sdk/Clients/ResourceClientBase.cs
@@ -77,9 +77,12 @@ public class ResourceClientBase : IResourceClientBase
         CancellationToken cancellationToken = default
     )
     {
-        _client.BaseUrl = requestArgs.Url.ToString();
-
-        return _client.PostQuoteAsync(body, requestArgs.AccessToken, cancellationToken);
+        return _client.PostQuoteAsync(
+            requestArgs.Url,
+            body,
+            requestArgs.AccessToken,
+            cancellationToken
+        );
     }
 
     public Task<QuoteResponse> GetQuoteAsync(
@@ -87,9 +90,7 @@ public class ResourceClientBase : IResourceClientBase
         CancellationToken cancellationToken = default
     )
     {
-        _client.BaseUrl = requestArgs.Url.ToString();
-
-        return _client.GetQuoteAsync(requestArgs.AccessToken, cancellationToken);
+        return _client.GetQuoteAsync(requestArgs.Url, requestArgs.AccessToken, cancellationToken);
     }
 
     public Task<OutgoingPaymentWithSpentAmountsResponse> CreateOutgoingPaymentAsync(

--- a/OpenPayments.Sdk/Generated/Auth/AuthServerClient.Methods.Grant.cs
+++ b/OpenPayments.Sdk/Generated/Auth/AuthServerClient.Methods.Grant.cs
@@ -5,6 +5,7 @@ namespace OpenPayments.Sdk.Generated.Auth;
 
 public partial class AuthServerClient
 {
+    /// <param name="authServerUrl">Auth server URL.</param>
     /// <param name="body">Body for grant request.</param>
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <summary>
@@ -16,10 +17,12 @@ public partial class AuthServerClient
     /// <returns>OK</returns>
     /// <exception cref="ErrorResponse">A server side error occurred.</exception>
     public async Task<AuthResponse> CreateGrantAsync(
+        Uri authServerUrl,
         GrantCreateBody body,
         CancellationToken cancellationToken = default
     )
     {
+        ArgumentNullException.ThrowIfNull(authServerUrl);
         ArgumentNullException.ThrowIfNull(body);
 
         var client = _httpClient;
@@ -30,9 +33,7 @@ public partial class AuthServerClient
         request.Content = content;
         request.Method = new HttpMethod("POST");
         request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
-        var urlBuilder = new System.Text.StringBuilder();
-        if (!string.IsNullOrEmpty(_baseUrl))
-            urlBuilder.Append(_baseUrl);
+        var urlBuilder = new System.Text.StringBuilder(authServerUrl.ToString());
 
         PrepareRequest(client, request, urlBuilder);
 

--- a/OpenPayments.Sdk/Generated/Auth/AuthServerClient.Methods.Grant.cs
+++ b/OpenPayments.Sdk/Generated/Auth/AuthServerClient.Methods.Grant.cs
@@ -22,7 +22,6 @@ public partial class AuthServerClient
         CancellationToken cancellationToken = default
     )
     {
-        ArgumentNullException.ThrowIfNull(authServerUrl);
         ArgumentNullException.ThrowIfNull(body);
 
         var client = _httpClient;

--- a/OpenPayments.Sdk/Generated/Resource/ResourceServerClient.Methods.IncomingPayment.cs
+++ b/OpenPayments.Sdk/Generated/Resource/ResourceServerClient.Methods.IncomingPayment.cs
@@ -23,6 +23,7 @@ public partial class ResourceServerClient
     /// <br/>
     /// <br/>If an `expiresAt` value is defined, and the current date and time on the receiving Account Servicing Entity's systems exceeds that value, the receiving Account Servicing Entity MUST reject any further payments.
     /// </remarks>
+    /// <param name="resourceServerUrl">The resource server URL to which the incoming-payments segment will be appended.</param>
     /// <param name="body">A subset of the incoming payments schema is accepted as input to create a new incoming payment.
     /// <br/>
     /// <br/>The `incomingAmount` must use the same `assetCode` and `assetScale` as the wallet address.</param>
@@ -147,6 +148,7 @@ public partial class ResourceServerClient
     /// <remarks>
     /// A client can fetch the latest state of an incoming payment to determine the amount received into the wallet address.
     /// </remarks>
+    /// <param name="incomingPaymentUrl">The absolute URL of the incoming payment to retrieve.</param>
     /// <param name="accessToken">Access Token.</param>
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <returns>Incoming Payment Found</returns>
@@ -265,6 +267,7 @@ public partial class ResourceServerClient
     /// <remarks>
     /// List all incoming payments on the wallet address
     /// </remarks>
+    /// <param name="resourceServerUrl">The resource server URL to which the incoming-payments segment will be appended.</param>
     /// <param name="accessToken">Access Token</param>
     /// <param name="walletAddress">URL of a wallet address hosted by a Rafiki instance.</param>
     /// <param name="cursor">The cursor key to list from.</param>
@@ -442,6 +445,7 @@ public partial class ResourceServerClient
     /// <br/>
     /// <br/>This indicates to the receiving Account Servicing Entity that it can begin any post processing of the payment such as generating account statements or notifying the account holder of the completed payment.
     /// </remarks>
+    /// <param name="incomingPaymentUrl">The absolute URL of the incoming payment to complete.</param>
     /// <param name="accessToken"></param>
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <returns>OK</returns>

--- a/OpenPayments.Sdk/Generated/Resource/ResourceServerClient.Methods.IncomingPayment.cs
+++ b/OpenPayments.Sdk/Generated/Resource/ResourceServerClient.Methods.IncomingPayment.cs
@@ -30,6 +30,7 @@ public partial class ResourceServerClient
     /// <returns>Incoming Payment Created</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
     public async Task<IncomingPaymentResponse> PostIncomingPaymentAsync(
+        Uri resourceServerUrl,
         Body body,
         string accessToken,
         CancellationToken cancellationToken
@@ -48,10 +49,7 @@ public partial class ResourceServerClient
         request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
         request.Headers.Authorization = new AuthenticationHeaderValue("GNAP", $"{accessToken}");
 
-        var urlBuilder = new StringBuilder();
-        if (!string.IsNullOrEmpty(_baseUrl))
-            urlBuilder.Append(_baseUrl);
-        urlBuilder.Append("incoming-payments");
+        var urlBuilder = new StringBuilder(AppendPath(resourceServerUrl, "incoming-payments"));
 
         PrepareRequest(client, request, urlBuilder);
 
@@ -154,6 +152,7 @@ public partial class ResourceServerClient
     /// <returns>Incoming Payment Found</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
     public virtual async Task<IncomingPaymentResponse> GetIncomingPaymentAsync(
+        Uri incomingPaymentUrl,
         string accessToken,
         CancellationToken cancellationToken
     )
@@ -166,7 +165,7 @@ public partial class ResourceServerClient
         request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
         request.Headers.Authorization = new AuthenticationHeaderValue("GNAP", $"{accessToken}");
 
-        var urlBuilder = new StringBuilder(_baseUrl);
+        var urlBuilder = new StringBuilder(incomingPaymentUrl.ToString());
 
         PrepareRequest(client, request, urlBuilder);
 
@@ -274,6 +273,7 @@ public partial class ResourceServerClient
     /// <returns>OK</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
     public virtual async Task<ListIncomingPaymentsResponse> ListIncomingPaymentsAsync(
+        Uri resourceServerUrl,
         string accessToken,
         string walletAddress,
         string? cursor,
@@ -291,10 +291,7 @@ public partial class ResourceServerClient
         request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
         request.Headers.Authorization = new AuthenticationHeaderValue("GNAP", $"{accessToken}");
 
-        var urlBuilder = new StringBuilder();
-        if (!string.IsNullOrEmpty(_baseUrl))
-            urlBuilder.Append(_baseUrl);
-        urlBuilder.Append("incoming-payments");
+        var urlBuilder = new StringBuilder(AppendPath(resourceServerUrl, "incoming-payments"));
         urlBuilder.Append('?');
         urlBuilder
             .Append(Uri.EscapeDataString("wallet-address"))
@@ -450,6 +447,7 @@ public partial class ResourceServerClient
     /// <returns>OK</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
     public virtual async Task<IncomingPaymentResponse> CompleteIncomingPaymentAsync(
+        Uri incomingPaymentUrl,
         string accessToken,
         CancellationToken cancellationToken
     )
@@ -463,8 +461,7 @@ public partial class ResourceServerClient
         request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
         request.Headers.Authorization = new AuthenticationHeaderValue("GNAP", $"{accessToken}");
 
-        var urlBuilder = new StringBuilder(_baseUrl);
-        urlBuilder.Append("/complete");
+        var urlBuilder = new StringBuilder(AppendPath(incomingPaymentUrl, "complete"));
 
         PrepareRequest(client, request, urlBuilder);
 

--- a/OpenPayments.Sdk/Generated/Resource/ResourceServerClient.Methods.OutgoingPayment.cs
+++ b/OpenPayments.Sdk/Generated/Resource/ResourceServerClient.Methods.OutgoingPayment.cs
@@ -14,6 +14,7 @@ public partial class ResourceServerClient
     /// <br/>
     /// <br/>Once created, it is already authorized and SHOULD be processed immediately. If payment fails, the Account Servicing Entity must mark the **outgoing payment** as `failed`.
     /// </remarks>
+    /// <param name="resourceServerUrl">The resource server URL to which the outgoing-payments segment will be appended.</param>
     /// <param name="body">A subset of the outgoing payments schema is accepted as input to create a new outgoing payment.
     /// <br/>
     /// <br/>The `debitAmount` must use the same `assetCode` and `assetScale` as the wallet address.
@@ -140,6 +141,7 @@ public partial class ResourceServerClient
     /// <remarks>
     /// A client can fetch the latest state of an outgoing payment.
     /// </remarks>
+    /// <param name="outgoingPaymentUrl">The absolute URL of the outgoing payment to retrieve.</param>
     /// <param name="accessToken">Access Token</param>
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <returns>Outgoing Payment Found</returns>
@@ -257,6 +259,7 @@ public partial class ResourceServerClient
     /// <remarks>
     /// List all outgoing payments on the wallet address
     /// </remarks>
+    /// <param name="resourceServerUrl">The resource server URL to which the outgoing-payments segment will be appended.</param>
     /// <param name="accessToken">Access Token</param>
     /// <param name="walletAddress">URL of a wallet address hosted by a Rafiki instance.</param>
     /// <param name="cursor">The cursor key to list from.</param>

--- a/OpenPayments.Sdk/Generated/Resource/ResourceServerClient.Methods.OutgoingPayment.cs
+++ b/OpenPayments.Sdk/Generated/Resource/ResourceServerClient.Methods.OutgoingPayment.cs
@@ -24,6 +24,7 @@ public partial class ResourceServerClient
     /// <returns>Outgoing Payment Created</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
     public async Task<OutgoingPaymentWithSpentAmountsResponse> PostOutgoingPaymentAsync(
+        Uri resourceServerUrl,
         OutgoingPaymentBody body,
         string accessToken,
         CancellationToken cancellationToken
@@ -40,10 +41,7 @@ public partial class ResourceServerClient
         request.Method = new HttpMethod("POST");
         request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
         request.Headers.Authorization = new AuthenticationHeaderValue("GNAP", $"{accessToken}");
-        var urlBuilder = new StringBuilder();
-        if (!string.IsNullOrEmpty(_baseUrl))
-            urlBuilder.Append(_baseUrl);
-        urlBuilder.Append("outgoing-payments");
+        var urlBuilder = new StringBuilder(AppendPath(resourceServerUrl, "outgoing-payments"));
 
         PrepareRequest(client, request, urlBuilder);
 
@@ -147,6 +145,7 @@ public partial class ResourceServerClient
     /// <returns>Outgoing Payment Found</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
     public virtual async Task<OutgoingPaymentResponse> GetOutgoingPaymentAsync(
+        Uri outgoingPaymentUrl,
         string accessToken,
         CancellationToken cancellationToken
     )
@@ -159,7 +158,7 @@ public partial class ResourceServerClient
         request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
         request.Headers.Authorization = new AuthenticationHeaderValue("GNAP", $"{accessToken}");
 
-        var urlBuilder = new StringBuilder(_baseUrl);
+        var urlBuilder = new StringBuilder(outgoingPaymentUrl.ToString());
 
         PrepareRequest(client, request, urlBuilder);
 
@@ -267,6 +266,7 @@ public partial class ResourceServerClient
     /// <returns>OK</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
     public virtual async Task<ListOutgoingPaymentsResponse> ListOutgoingPaymentsAsync(
+        Uri resourceServerUrl,
         string accessToken,
         string walletAddress,
         string? cursor,
@@ -284,10 +284,7 @@ public partial class ResourceServerClient
         request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
         request.Headers.Authorization = new AuthenticationHeaderValue("GNAP", $"{accessToken}");
 
-        var urlBuilder = new StringBuilder();
-        if (!string.IsNullOrEmpty(_baseUrl))
-            urlBuilder.Append(_baseUrl);
-        urlBuilder.Append("outgoing-payments");
+        var urlBuilder = new StringBuilder(AppendPath(resourceServerUrl, "outgoing-payments"));
         urlBuilder.Append('?');
         urlBuilder
             .Append(Uri.EscapeDataString("wallet-address"))

--- a/OpenPayments.Sdk/Generated/Resource/ResourceServerClient.Methods.Quote.cs
+++ b/OpenPayments.Sdk/Generated/Resource/ResourceServerClient.Methods.Quote.cs
@@ -12,6 +12,7 @@ public partial class ResourceServerClient
     /// <remarks>
     /// A **quote** is a sub-resource of a wallet address. It represents a quote for a payment from the wallet address.
     /// </remarks>
+    /// <param name="resourceServerUrl">The resource server URL to which the quotes segment will be appended.</param>
     /// <param name="body">A subset of the quotes schema is accepted as input to create a new quote.
     /// <br/>
     /// <br/>The quote must be created with a (`debitAmount` xor `receiveAmount`) unless the `receiver` is an Incoming Payment which has an `incomingAmount`.</param>
@@ -20,6 +21,7 @@ public partial class ResourceServerClient
     /// <returns>Quote Created</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
     public async Task<QuoteResponse> PostQuoteAsync(
+        Uri resourceServerUrl,
         QuoteBody body,
         string accessToken,
         CancellationToken cancellationToken
@@ -38,10 +40,7 @@ public partial class ResourceServerClient
         request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
         request.Headers.Authorization = new AuthenticationHeaderValue("GNAP", $"{accessToken}");
 
-        var urlBuilder = new StringBuilder();
-        if (!string.IsNullOrEmpty(_baseUrl))
-            urlBuilder.Append(_baseUrl);
-        urlBuilder.Append("quotes");
+        var urlBuilder = new StringBuilder(AppendPath(resourceServerUrl, "quotes"));
 
         PrepareRequest(client, request, urlBuilder);
 
@@ -140,11 +139,13 @@ public partial class ResourceServerClient
     /// <remarks>
     /// A client can fetch the latest state of a quote.
     /// </remarks>
+    /// <param name="quoteUrl">The absolute URL of the quote to retrieve.</param>
     /// <param name="accessToken">Access Token.</param>
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <returns>Quote Found</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
     public virtual async Task<QuoteResponse> GetQuoteAsync(
+        Uri quoteUrl,
         string accessToken,
         CancellationToken cancellationToken
     )
@@ -157,7 +158,7 @@ public partial class ResourceServerClient
         request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
         request.Headers.Authorization = new AuthenticationHeaderValue("GNAP", $"{accessToken}");
 
-        var urlBuilder = new StringBuilder(_baseUrl);
+        var urlBuilder = new StringBuilder(quoteUrl.ToString());
 
         PrepareRequest(client, request, urlBuilder);
 

--- a/OpenPayments.Sdk/Generated/Resource/ResourceServerClient.Urls.cs
+++ b/OpenPayments.Sdk/Generated/Resource/ResourceServerClient.Urls.cs
@@ -1,0 +1,11 @@
+namespace OpenPayments.Sdk.Generated.Resource;
+
+public partial class ResourceServerClient
+{
+    /// <summary>
+    /// Joins <paramref name="segment"/> onto <paramref name="baseUrl"/> with exactly one
+    /// separating slash, whether or not the caller's URL carries a trailing one.
+    /// </summary>
+    private static string AppendPath(Uri baseUrl, string segment) =>
+        $"{baseUrl.ToString().TrimEnd('/')}/{segment}";
+}


### PR DESCRIPTION
## Summary

Removes the shared mutable `BaseUrl` from `ResourceClientBase` and `AuthClientBase` so a singleton client can serve concurrent requests to different wallet addresses without cross-talk. Ten hand-written methods on `ResourceServerClient`/`AuthServerClient` now take their target `Uri` as an explicit first parameter and build their URL from that parameter, instead of reading a `_baseUrl` field their wrapper mutated immediately before the call. This is the same pattern already used by `ContinueGrantAsync(Uri continueUrl, ...)`, `RotateTokenAsync(Uri tokenUrl, ...)`, and `WalletAddressClient.GetWalletAddressAsync(string walletAddress, ...)`.

- Closes #16.
- Three URLs change on the wire, all corrections: the three GET endpoints lose a trailing slash, complete-incoming-payment loses a double slash, and grant requests to a pathful auth server lose a trailing slash. Because `@target-uri` is a signed component of the HTTP message signature, the previous code also signed over the malformed URI.
- `ResourceServerClient` and `AuthServerClient` are `public` types, so their hand-written method signatures changing is source-breaking for anyone calling them directly rather than through `IAuthenticatedClient`. The supported surface (`IResourceClientBase`, `IAuthClientBase`, `IAuthenticatedClient`) is unchanged.
- Adds a CI guard (`.github/workflows/build.yaml`) that fails the build if `BaseUrl =` is reintroduced anywhere in hand-written code under `OpenPayments.Sdk/` (excluding generated `*.g.cs` constructors).

## Test plan

- [x] `dotnet test` — 78/78 passing (49 SDK tests, 29 HttpSignatureUtils tests)
- [x] `dotnet build --configuration Release` — clean, no new warnings
- [x] `dotnet build OpenPayments.Snippets/OpenPayments.Snippets.csproj` — compiles unchanged, confirming the public surface didn't move
- [x] New `RecordingHandler` test double + cross-host/200-iteration parallel tests exercise the concurrency fix directly
- [x] CI guard verified to catch a reintroduced `BaseUrl =` write and to pass cleanly on the current tree