### PR TITLE
docs(NET-22): Bring documentation to release quality

### DIFF
--- a/OpenPayments.Sdk.HttpSignatureUtils/OpenPayments.Sdk.HttpSignatureUtils.csproj
+++ b/OpenPayments.Sdk.HttpSignatureUtils/OpenPayments.Sdk.HttpSignatureUtils.csproj
@@ -4,12 +4,19 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RootNamespace>Interledger.OpenPayments.HttpSignatureUtils</RootNamespace>
     <PackageId>Interledger.OpenPayments.HttpSignatureUtils</PackageId>
     <Authors>Interledger.OpenPayments.HttpSignatureUtils</Authors>
     <Company>Interledger</Company>
     <Product>OpenPayments.HttpSignatureUtils</Product>
     <AssemblyName>Interledger.OpenPayments.HttpSignatureUtils</AssemblyName>
+    <Description>HTTP Message Signatures (RFC 9421) utilities for Open Payments — Ed25519 request signing and verification. Usable standalone.</Description>
+    <RepositoryUrl>https://github.com/interledger/open-payments-dotnet</RepositoryUrl>
+    <PackageTags>interledger openpayments http-message-signatures rfc9421</PackageTags>
+    <PackageProjectUrl>https://openpayments.dev/</PackageProjectUrl>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NSec.Cryptography" Version="25.4.0"/>
@@ -17,5 +24,7 @@
     <PackageReference Include="Sodium.Core" Version="1.4.0"/>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
     <InternalsVisibleTo Include="../OpenPayments.Sdk.HttpSignatureUtils.Tests"/>
+    <None Include="../LICENSE" Pack="true" PackagePath=""/>
+    <None Include="README.md" Pack="true" PackagePath=""/>
   </ItemGroup>
 </Project>

--- a/OpenPayments.Sdk.HttpSignatureUtils/README.md
+++ b/OpenPayments.Sdk.HttpSignatureUtils/README.md
@@ -1,0 +1,57 @@
+# Open Payments .NET HTTP Signature Utils
+
+Standalone utilities implementing [HTTP Message Signatures (RFC 9421)](https://datatracker.ietf.org/doc/html/rfc9421)
+with the Ed25519 algorithm, as required by the [Open Payments](https://openpayments.dev/) authentication
+scheme. Usable on its own, independent of the rest of the Open Payments .NET SDK.
+
+## Supported frameworks
+
+Targets `net8.0`. This is independent of `Interledger.OpenPayments` (which targets `net9.0` and depends on
+this package) — you can use this package standalone on an older runtime.
+
+## Install
+
+```bash
+dotnet add package Interledger.OpenPayments.HttpSignatureUtils
+```
+
+## Signing a request
+
+```csharp
+using System.Text;
+using OpenPayments.Sdk.HttpSignatureUtils;
+
+var privateKey = KeyUtils.LoadPem(privateKeyPem);
+var request = new HttpRequestMessage(HttpMethod.Post, "https://example.com/incoming-payments")
+{
+    Content = new StringContent("{\"walletAddress\":\"https://example.com/alice\"}", Encoding.UTF8, "application/json"),
+};
+
+var headers = await HttpRequestSigner.SignHttpRequestAsync(request, privateKey, keyId);
+request.Headers.TryAddWithoutValidation("Signature", headers.Signature);
+request.Headers.TryAddWithoutValidation("Signature-Input", headers.SignatureInput);
+```
+
+## Verifying a request
+
+```csharp
+using OpenPayments.Sdk.HttpSignatureUtils;
+
+var validator = new HttpSignatureValidator(
+    new SignatureInputParser(),
+    new SignatureInputValidator(),
+    new SignatureInputBuilder());
+
+var clientKey = new Jwk { Kid = keyId, X = base64UrlEncodedPublicKey };
+
+if (validator.AreSignatureHeadersPresent(incomingRequest))
+{
+    bool isValid = await validator.ValidateSignatureAsync(incomingRequest, clientKey);
+}
+```
+
+## Versioning
+
+This package follows [Semantic Versioning](https://semver.org/). See the project's
+[GitHub Releases](https://github.com/interledger/open-payments-dotnet/releases) for change history —
+release notes are generated automatically from merged pull requests.

--- a/OpenPayments.Sdk/Clients/AuthClientBase.cs
+++ b/OpenPayments.Sdk/Clients/AuthClientBase.cs
@@ -6,8 +6,9 @@ namespace OpenPayments.Sdk.Clients;
 
 /// <summary>
 /// Default <see cref="IAuthClientBase"/> implementation. Wraps a signed <see cref="AuthServerClient"/>,
-/// rewriting its base URL on every call from <see cref="RequestArgs.Url"/> since a single auth server
-/// client is shared across requests to different authorization servers.
+/// passing the target URL from <see cref="RequestArgs.Url"/> on each call (rewriting <c>BaseUrl</c> for
+/// the initial grant request) since a single auth server client is shared across requests to different
+/// authorization servers.
 /// </summary>
 public class AuthClientBase : IAuthClientBase
 {

--- a/OpenPayments.Sdk/Clients/AuthClientBase.cs
+++ b/OpenPayments.Sdk/Clients/AuthClientBase.cs
@@ -4,11 +4,23 @@ using OpenPayments.Sdk.Generated.Auth;
 
 namespace OpenPayments.Sdk.Clients;
 
+/// <summary>
+/// Default <see cref="IAuthClientBase"/> implementation. Wraps a signed <see cref="AuthServerClient"/>,
+/// rewriting its base URL on every call from <see cref="RequestArgs.Url"/> since a single auth server
+/// client is shared across requests to different authorization servers.
+/// </summary>
 public class AuthClientBase : IAuthClientBase
 {
     private readonly AuthServerClient _client;
     private readonly HttpClient _httpClient;
 
+    /// <summary>
+    /// Creates a new <see cref="AuthClientBase"/> that signs every outgoing request with the given key.
+    /// </summary>
+    /// <param name="http">Pre-configured <see cref="HttpClient"/> instance. Its <see cref="HttpClient.BaseAddress"/> is ignored; absolute request URIs are used instead.</param>
+    /// <param name="privateKey">Private key used to sign requests.</param>
+    /// <param name="keyId">Key ID used to sign requests.</param>
+    /// <param name="clientUrl">Client wallet address URL (e.g. <c>https://wallet.example/alice</c>).</param>
     public AuthClientBase(HttpClient http, Key privateKey, string keyId, Uri clientUrl)
     {
         _httpClient = http;
@@ -17,6 +29,7 @@ public class AuthClientBase : IAuthClientBase
         _client.ClientUrl = clientUrl;
     }
 
+    /// <inheritdoc/>
     public async Task<AuthResponse> RequestGrantAsync(
         RequestArgs requestArgs,
         GrantCreateBody body,
@@ -29,6 +42,7 @@ public class AuthClientBase : IAuthClientBase
         return await _client.CreateGrantAsync(body, cancellationToken).ConfigureAwait(false);
     }
 
+    /// <inheritdoc/>
     public async Task<AuthResponse> ContinueGrantAsync(
         AuthRequestArgs requestArgs,
         GrantContinueBody body,
@@ -40,6 +54,7 @@ public class AuthClientBase : IAuthClientBase
             .ConfigureAwait(false);
     }
 
+    /// <inheritdoc/>
     public async Task CancelGrantAsync(
         AuthRequestArgs requestArgs,
         CancellationToken cancellationToken
@@ -50,6 +65,7 @@ public class AuthClientBase : IAuthClientBase
             .ConfigureAwait(false);
     }
 
+    /// <inheritdoc/>
     public async Task<RotateTokenResponse> RotateTokenAsync(
         AuthRequestArgs requestArgs,
         CancellationToken cancellationToken
@@ -60,6 +76,7 @@ public class AuthClientBase : IAuthClientBase
             .ConfigureAwait(false);
     }
 
+    /// <inheritdoc/>
     public async Task RevokeTokenAsync(
         AuthRequestArgs requestArgs,
         CancellationToken cancellationToken = default
@@ -71,27 +88,61 @@ public class AuthClientBase : IAuthClientBase
     }
 }
 
+/// <summary>
+/// Authorization-server operations (grant request, continuation, cancellation, and token
+/// rotation/revocation) available to an authenticated Open Payments client.
+/// </summary>
 public interface IAuthClientBase
 {
+    /// <summary>
+    /// Requests a new access grant from the authorization server.
+    /// </summary>
+    /// <param name="requestArgs">The authorization server URL to send the request to.</param>
+    /// <param name="body">The grant request body, describing the access being requested.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns>The grant response — either a completed grant, or one requiring interaction/continuation.</returns>
     public Task<AuthResponse> RequestGrantAsync(
         RequestArgs requestArgs,
         GrantCreateBody body,
         CancellationToken cancellationToken = default
     );
 
+    /// <summary>
+    /// Continues a pending grant request after the client has finished any required interaction.
+    /// </summary>
+    /// <param name="requestArgs">The grant continuation URL and continuation access token to use for the request.</param>
+    /// <param name="body">The continuation request body, including the interaction reference.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns>The completed grant response.</returns>
     public Task<AuthResponse> ContinueGrantAsync(
         AuthRequestArgs requestArgs,
         GrantContinueBody body,
         CancellationToken cancellationToken = default
     );
 
+    /// <summary>
+    /// Cancels a pending or active grant.
+    /// </summary>
+    /// <param name="requestArgs">The grant URL and continuation access token to use for the request.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     public Task CancelGrantAsync(AuthRequestArgs requestArgs, CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Rotates an access token, exchanging it for a newly issued token with the same access rights.
+    /// </summary>
+    /// <param name="requestArgs">The token management URL and current access token to use for the request.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns>The rotated access token.</returns>
     public Task<RotateTokenResponse> RotateTokenAsync(
         AuthRequestArgs requestArgs,
         CancellationToken cancellationToken
     );
 
+    /// <summary>
+    /// Revokes an access token, ending the grant it was issued under.
+    /// </summary>
+    /// <param name="requestArgs">The token management URL and access token to revoke.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     public Task RevokeTokenAsync(
         AuthRequestArgs requestArgs,
         CancellationToken cancellationToken = default

--- a/OpenPayments.Sdk/Clients/AuthenticatedClient.cs
+++ b/OpenPayments.Sdk/Clients/AuthenticatedClient.cs
@@ -205,12 +205,24 @@ internal sealed class AuthenticatedClient(
     }
 }
 
+/// <summary>
+/// Arguments identifying the target URL for an unauthenticated request (e.g. an initial grant request).
+/// </summary>
 public class RequestArgs
 {
+    /// <summary>
+    /// The absolute URL to send the request to.
+    /// </summary>
     public required Uri Url { get; set; }
 }
 
+/// <summary>
+/// Arguments identifying the target URL and access token for an authenticated request.
+/// </summary>
 public class AuthRequestArgs : RequestArgs
 {
+    /// <summary>
+    /// The access token to present with the request.
+    /// </summary>
     public required string AccessToken { get; set; }
 }

--- a/OpenPayments.Sdk/Clients/ResourceClientBase.cs
+++ b/OpenPayments.Sdk/Clients/ResourceClientBase.cs
@@ -6,7 +6,7 @@ namespace OpenPayments.Sdk.Clients;
 /// <summary>
 /// Default <see cref="IResourceClientBase"/> implementation. Wraps a signed
 /// <see cref="ResourceServerClient"/>, rewriting its base URL on every call from
-/// <see cref="AuthRequestArgs.Url"/> since a single resource server client is shared across requests to
+/// <see cref="RequestArgs.Url"/> since a single resource server client is shared across requests to
 /// different resource servers.
 /// </summary>
 public class ResourceClientBase : IResourceClientBase

--- a/OpenPayments.Sdk/Clients/ResourceClientBase.cs
+++ b/OpenPayments.Sdk/Clients/ResourceClientBase.cs
@@ -3,11 +3,24 @@ using OpenPayments.Sdk.Generated.Resource;
 
 namespace OpenPayments.Sdk.Clients;
 
+/// <summary>
+/// Default <see cref="IResourceClientBase"/> implementation. Wraps a signed
+/// <see cref="ResourceServerClient"/>, rewriting its base URL on every call from
+/// <see cref="AuthRequestArgs.Url"/> since a single resource server client is shared across requests to
+/// different resource servers.
+/// </summary>
 public class ResourceClientBase : IResourceClientBase
 {
     private readonly ResourceServerClient _client;
     private readonly HttpClient _httpClient;
 
+    /// <summary>
+    /// Creates a new <see cref="ResourceClientBase"/> that signs every outgoing request with the given key.
+    /// </summary>
+    /// <param name="http">Pre-configured <see cref="HttpClient"/> instance. Its <see cref="HttpClient.BaseAddress"/> is ignored; absolute request URIs are used instead.</param>
+    /// <param name="privateKey">Private key used to sign requests.</param>
+    /// <param name="keyId">Key ID used to sign requests.</param>
+    /// <param name="clientUrl">Client wallet address URL (e.g. <c>https://wallet.example/alice</c>).</param>
     public ResourceClientBase(HttpClient http, Key privateKey, string keyId, Uri clientUrl)
     {
         _httpClient = http;
@@ -16,6 +29,7 @@ public class ResourceClientBase : IResourceClientBase
         _client.ClientUrl = clientUrl;
     }
 
+    /// <inheritdoc/>
     public Task<IncomingPaymentResponse> CreateIncomingPaymentAsync(
         AuthRequestArgs requestArgs,
         Body body,
@@ -27,6 +41,7 @@ public class ResourceClientBase : IResourceClientBase
         return _client.PostIncomingPaymentAsync(body, requestArgs.AccessToken, cancellationToken);
     }
 
+    /// <inheritdoc/>
     public Task<IncomingPaymentResponse> GetIncomingPaymentAsync(
         AuthRequestArgs requestArgs,
         CancellationToken cancellationToken = default
@@ -37,6 +52,7 @@ public class ResourceClientBase : IResourceClientBase
         return _client.GetIncomingPaymentAsync(requestArgs.AccessToken, cancellationToken);
     }
 
+    /// <inheritdoc/>
     public Task<IncomingPaymentResponse> CompleteIncomingPaymentAsync(
         AuthRequestArgs requestArgs,
         CancellationToken cancellationToken = default
@@ -47,6 +63,7 @@ public class ResourceClientBase : IResourceClientBase
         return _client.CompleteIncomingPaymentAsync(requestArgs.AccessToken, cancellationToken);
     }
 
+    /// <inheritdoc/>
     public Task<ListIncomingPaymentsResponse> ListIncomingPaymentsAsync(
         AuthRequestArgs requestArgs,
         ListIncomingPaymentQuery query,
@@ -65,6 +82,7 @@ public class ResourceClientBase : IResourceClientBase
         );
     }
 
+    /// <inheritdoc/>
     public Task<QuoteResponse> CreateQuoteAsync(
         AuthRequestArgs requestArgs,
         QuoteBody body,
@@ -76,6 +94,7 @@ public class ResourceClientBase : IResourceClientBase
         return _client.PostQuoteAsync(body, requestArgs.AccessToken, cancellationToken);
     }
 
+    /// <inheritdoc/>
     public Task<QuoteResponse> GetQuoteAsync(
         AuthRequestArgs requestArgs,
         CancellationToken cancellationToken = default
@@ -86,6 +105,7 @@ public class ResourceClientBase : IResourceClientBase
         return _client.GetQuoteAsync(requestArgs.AccessToken, cancellationToken);
     }
 
+    /// <inheritdoc/>
     public Task<OutgoingPaymentWithSpentAmountsResponse> CreateOutgoingPaymentAsync(
         AuthRequestArgs requestArgs,
         OutgoingPaymentBody body,
@@ -97,6 +117,7 @@ public class ResourceClientBase : IResourceClientBase
         return _client.PostOutgoingPaymentAsync(body, requestArgs.AccessToken, cancellationToken);
     }
 
+    /// <inheritdoc/>
     public Task<OutgoingPaymentResponse> GetOutgoingPaymentAsync(
         AuthRequestArgs requestArgs,
         CancellationToken cancellationToken = default
@@ -107,6 +128,7 @@ public class ResourceClientBase : IResourceClientBase
         return _client.GetOutgoingPaymentAsync(requestArgs.AccessToken, cancellationToken);
     }
 
+    /// <inheritdoc/>
     public Task<ListOutgoingPaymentsResponse> ListOutgoingPaymentAsync(
         AuthRequestArgs requestArgs,
         ListOutgoingPaymentQuery query,
@@ -126,52 +148,115 @@ public class ResourceClientBase : IResourceClientBase
     }
 }
 
+/// <summary>
+/// Resource-server operations (incoming payments, quotes, outgoing payments) available to an authenticated
+/// Open Payments client.
+/// </summary>
 public interface IResourceClientBase
 {
+    /// <summary>
+    /// Creates an incoming payment on the resource server.
+    /// </summary>
+    /// <param name="requestArgs">The resource server URL and access token to use for the request.</param>
+    /// <param name="body">The incoming payment properties to create.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns>The created incoming payment.</returns>
     public Task<IncomingPaymentResponse> CreateIncomingPaymentAsync(
         AuthRequestArgs requestArgs,
         Body body,
         CancellationToken cancellationToken = default
     );
 
+    /// <summary>
+    /// Retrieves an existing incoming payment from the resource server.
+    /// </summary>
+    /// <param name="requestArgs">The incoming payment URL and access token to use for the request.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns>The requested incoming payment.</returns>
     public Task<IncomingPaymentResponse> GetIncomingPaymentAsync(
         AuthRequestArgs requestArgs,
         CancellationToken cancellationToken = default
     );
 
+    /// <summary>
+    /// Marks an incoming payment as completed, indicating no further funds will be received against it.
+    /// </summary>
+    /// <param name="requestArgs">The incoming payment URL and access token to use for the request.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns>The completed incoming payment.</returns>
     public Task<IncomingPaymentResponse> CompleteIncomingPaymentAsync(
         AuthRequestArgs requestArgs,
         CancellationToken cancellationToken = default
     );
 
+    /// <summary>
+    /// Lists the incoming payments for a wallet address.
+    /// </summary>
+    /// <param name="requestArgs">The resource server URL and access token to use for the request.</param>
+    /// <param name="query">Filtering and pagination parameters for the list.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns>A page of matching incoming payments.</returns>
     public Task<ListIncomingPaymentsResponse> ListIncomingPaymentsAsync(
         AuthRequestArgs requestArgs,
         ListIncomingPaymentQuery query,
         CancellationToken cancellationToken = default
     );
 
+    /// <summary>
+    /// Creates a quote on the resource server.
+    /// </summary>
+    /// <param name="requestArgs">The resource server URL and access token to use for the request.</param>
+    /// <param name="body">The quote properties to create.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns>The created quote.</returns>
     public Task<QuoteResponse> CreateQuoteAsync(
         AuthRequestArgs requestArgs,
         QuoteBody body,
         CancellationToken cancellationToken = default
     );
 
+    /// <summary>
+    /// Retrieves an existing quote from the resource server.
+    /// </summary>
+    /// <param name="requestArgs">The quote URL and access token to use for the request.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns>The requested quote.</returns>
     public Task<QuoteResponse> GetQuoteAsync(
         AuthRequestArgs requestArgs,
         CancellationToken cancellationToken = default
     );
 
+    /// <summary>
+    /// Creates an outgoing payment on the resource server.
+    /// </summary>
+    /// <param name="requestArgs">The resource server URL and access token to use for the request.</param>
+    /// <param name="body">The outgoing payment properties to create.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns>The created outgoing payment, including the amounts spent against it so far.</returns>
     public Task<OutgoingPaymentWithSpentAmountsResponse> CreateOutgoingPaymentAsync(
         AuthRequestArgs requestArgs,
         OutgoingPaymentBody body,
         CancellationToken cancellationToken = default
     );
 
+    /// <summary>
+    /// Retrieves an existing outgoing payment from the resource server.
+    /// </summary>
+    /// <param name="requestArgs">The outgoing payment URL and access token to use for the request.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns>The requested outgoing payment.</returns>
     public Task<OutgoingPaymentResponse> GetOutgoingPaymentAsync(
         AuthRequestArgs requestArgs,
         CancellationToken cancellationToken = default
     );
 
+    /// <summary>
+    /// Lists the outgoing payments for a wallet address.
+    /// </summary>
+    /// <param name="requestArgs">The resource server URL and access token to use for the request.</param>
+    /// <param name="query">Filtering and pagination parameters for the list.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns>A page of matching outgoing payments.</returns>
     public Task<ListOutgoingPaymentsResponse> ListOutgoingPaymentAsync(
         AuthRequestArgs requestArgs,
         ListOutgoingPaymentQuery query,

--- a/OpenPayments.Sdk/Configuration/OpenPaymentsOptions.cs
+++ b/OpenPayments.Sdk/Configuration/OpenPaymentsOptions.cs
@@ -9,7 +9,8 @@ namespace OpenPayments.Sdk.Configuration;
 /// </summary>
 /// <remarks>
 /// Used with <see cref="ServiceCollectionExtensions.UseOpenPayments"/> to select between
-/// authenticated and unauthenticated client setups./// </remarks>
+/// authenticated and unauthenticated client setups.
+/// </remarks>
 public class OpenPaymentsOptions
 {
     /// <summary>
@@ -18,7 +19,7 @@ public class OpenPaymentsOptions
     public bool UseUnauthenticatedClient { get; set; }
 
     /// <summary>
-    /// Indicates whether the authenticated client (<c>IAuthenticatedClient</c>) should be registered.
+    /// Indicates whether the authenticated client (<see cref="IAuthenticatedClient"/>) should be registered.
     /// </summary>
     public bool UseAuthenticatedClient { get; set; }
 

--- a/OpenPayments.Sdk/Configuration/OpenPaymentsOptions.cs
+++ b/OpenPayments.Sdk/Configuration/OpenPaymentsOptions.cs
@@ -17,11 +17,26 @@ public class OpenPaymentsOptions
     /// </summary>
     public bool UseUnauthenticatedClient { get; set; }
 
+    /// <summary>
+    /// Indicates whether the authenticated client (<c>IAuthenticatedClient</c>) should be registered.
+    /// </summary>
     public bool UseAuthenticatedClient { get; set; }
 
+    /// <summary>
+    /// Key identifier (<c>kid</c>) associated with <see cref="PrivateKey"/>, sent alongside signed
+    /// requests. Required when <see cref="UseAuthenticatedClient"/> is <c>true</c>.
+    /// </summary>
     public string? KeyId { get; set; }
 
+    /// <summary>
+    /// Private key used to sign requests made by the authenticated client. Required when
+    /// <see cref="UseAuthenticatedClient"/> is <c>true</c>.
+    /// </summary>
     public Key? PrivateKey { get; set; }
 
+    /// <summary>
+    /// The client's own wallet address, used to identify the client making grant requests. Required when
+    /// <see cref="UseAuthenticatedClient"/> is <c>true</c>.
+    /// </summary>
     public Uri? ClientUrl { get; set; }
 }

--- a/OpenPayments.Sdk/Generated/.editorconfig
+++ b/OpenPayments.Sdk/Generated/.editorconfig
@@ -1,0 +1,11 @@
+# Suppresses CS1591 (missing XML doc comment) for pure NSwag-generated output only.
+# Do not widen these patterns — everything else under Generated/ is hand-authored and must be documented.
+
+[*.g.cs]
+dotnet_diagnostic.CS1591.severity = none
+
+[Auth/Types.cs]
+dotnet_diagnostic.CS1591.severity = none
+
+[Resource/Types.cs]
+dotnet_diagnostic.CS1591.severity = none

--- a/OpenPayments.Sdk/Generated/Auth/AuthContractResolver.cs
+++ b/OpenPayments.Sdk/Generated/Auth/AuthContractResolver.cs
@@ -3,8 +3,14 @@ using Newtonsoft.Json.Serialization;
 
 namespace OpenPayments.Sdk.Generated.Auth;
 
+/// <summary>
+/// Newtonsoft.Json contract resolver used when (de)serializing requests and responses for the generated
+/// Auth server client. Relaxes <see cref="Required.Always"/> constraints and ignores null values so
+/// partially populated request/response models don't throw during (de)serialization.
+/// </summary>
 public sealed class AuthContractResolver : DefaultContractResolver
 {
+    /// <inheritdoc/>
     protected override JsonProperty CreateProperty(System.Reflection.MemberInfo member,
         MemberSerialization memberSerialization)
     {

--- a/OpenPayments.Sdk/Generated/Auth/AuthServerClient.Auth.cs
+++ b/OpenPayments.Sdk/Generated/Auth/AuthServerClient.Auth.cs
@@ -13,8 +13,8 @@ public partial class AuthServerClient
     private string? _keyId;
 
     /// <summary>
-    /// The authorization server URL that requests are sent to. Set before each call via <c>BaseUrl</c>,
-    /// since a single client instance is reused across requests to different authorization servers.
+    /// The client's own wallet address, sent as the <c>client</c> field of grant requests to identify the
+    /// requesting client. This is not the server URL — that is set per-call via <c>BaseUrl</c>.
     /// </summary>
     public Uri ClientUrl { get; set; }
 

--- a/OpenPayments.Sdk/Generated/Auth/AuthServerClient.Auth.cs
+++ b/OpenPayments.Sdk/Generated/Auth/AuthServerClient.Auth.cs
@@ -3,12 +3,26 @@ using NSec.Cryptography;
 
 namespace OpenPayments.Sdk.Generated.Auth;
 
+/// <summary>
+/// Hand-written extensions to the generated <see cref="AuthServerClient"/> that add HTTP Message
+/// Signature support and route requests through the client-configured contract resolver.
+/// </summary>
 public partial class AuthServerClient
 {
     private Key? _privateKey;
     private string? _keyId;
+
+    /// <summary>
+    /// The authorization server URL that requests are sent to. Set before each call via <c>BaseUrl</c>,
+    /// since a single client instance is reused across requests to different authorization servers.
+    /// </summary>
     public Uri ClientUrl { get; set; }
 
+    /// <summary>
+    /// Sets the key used to sign every subsequent request made by this client.
+    /// </summary>
+    /// <param name="privateKey">Private key used to sign requests.</param>
+    /// <param name="keyId">Key ID sent alongside the signature.</param>
     public void AddSigningKey(Key privateKey, string keyId)
     {
         _privateKey = privateKey;

--- a/OpenPayments.Sdk/Generated/Resource/ResourceContractResolver.cs
+++ b/OpenPayments.Sdk/Generated/Resource/ResourceContractResolver.cs
@@ -3,8 +3,13 @@ using Newtonsoft.Json.Serialization;
 
 namespace OpenPayments.Sdk.Generated.Resource;
 
+/// <summary>
+/// Newtonsoft.Json contract resolver used when (de)serializing requests and responses for the generated
+/// Resource server client.
+/// </summary>
 public sealed class ResourceContractResolver : DefaultContractResolver
 {
+    /// <inheritdoc/>
     protected override JsonProperty CreateProperty(System.Reflection.MemberInfo member,
         MemberSerialization memberSerialization)
     {

--- a/OpenPayments.Sdk/Generated/Resource/ResourceServerClient.Auth.cs
+++ b/OpenPayments.Sdk/Generated/Resource/ResourceServerClient.Auth.cs
@@ -13,8 +13,8 @@ public partial class ResourceServerClient
     private string? _keyId;
 
     /// <summary>
-    /// The resource server URL that requests are sent to. Set before each call via <c>BaseUrl</c>, since a
-    /// single client instance is reused across requests to different resource servers.
+    /// The client's own wallet address, identifying the requesting client. This is not the server URL —
+    /// that is set per-call via <c>BaseUrl</c>.
     /// </summary>
     public Uri ClientUrl { get; set; }
 

--- a/OpenPayments.Sdk/Generated/Resource/ResourceServerClient.Auth.cs
+++ b/OpenPayments.Sdk/Generated/Resource/ResourceServerClient.Auth.cs
@@ -3,12 +3,26 @@ using NSec.Cryptography;
 
 namespace OpenPayments.Sdk.Generated.Resource;
 
+/// <summary>
+/// Hand-written extensions to the generated <see cref="ResourceServerClient"/> that add HTTP Message
+/// Signature support and route requests through the client-configured contract resolver.
+/// </summary>
 public partial class ResourceServerClient
 {
     private Key? _privateKey;
     private string? _keyId;
+
+    /// <summary>
+    /// The resource server URL that requests are sent to. Set before each call via <c>BaseUrl</c>, since a
+    /// single client instance is reused across requests to different resource servers.
+    /// </summary>
     public Uri ClientUrl { get; set; }
 
+    /// <summary>
+    /// Sets the key used to sign every subsequent request made by this client.
+    /// </summary>
+    /// <param name="privateKey">Private key used to sign requests.</param>
+    /// <param name="keyId">Key ID sent alongside the signature.</param>
     public void AddSigningKey(Key privateKey, string keyId)
     {
         _privateKey = privateKey;

--- a/OpenPayments.Sdk/Generated/Types.cs
+++ b/OpenPayments.Sdk/Generated/Types.cs
@@ -1,9 +1,16 @@
 namespace OpenPayments.Sdk.Generated
 {
+    /// <summary>
+    /// Base class shared by generated models that captures any JSON properties present on the wire but not
+    /// mapped to a declared member.
+    /// </summary>
     public abstract partial class Anonymous
     {
         private IDictionary<string, object>? _additionalProperties;
 
+        /// <summary>
+        /// JSON properties present on the response but not declared on the generated type.
+        /// </summary>
         [Newtonsoft.Json.JsonExtensionData]
         public IDictionary<string, object> AdditionalProperties
         {
@@ -12,8 +19,17 @@ namespace OpenPayments.Sdk.Generated
         }
     }
 
+    /// <summary>
+    /// Helper utilities shared by the generated Auth, Resource, and Wallet clients.
+    /// </summary>
     public static class Helpers
     {
+        /// <summary>
+        /// Combines an <see cref="HttpResponseMessage"/>'s response headers and content headers into a
+        /// single dictionary.
+        /// </summary>
+        /// <param name="response">The HTTP response to extract headers from.</param>
+        /// <returns>A dictionary mapping header name to its values.</returns>
         public static Dictionary<string, IEnumerable<string>> ExtractHeaders(HttpResponseMessage response)
         {
             var headers = new Dictionary<string, IEnumerable<string>>();

--- a/OpenPayments.Sdk/Generated/Wallet/WalletAddressClient.Methods.cs
+++ b/OpenPayments.Sdk/Generated/Wallet/WalletAddressClient.Methods.cs
@@ -4,6 +4,13 @@ namespace OpenPayments.Sdk.Generated.Wallet
 {
     public partial class WalletAddressClient
     {
+        /// <summary>
+        /// Retrieves the public information of a wallet address.
+        /// </summary>
+        /// <param name="walletAddress">The absolute wallet address URL.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>The wallet address's public information.</returns>
+        /// <exception cref="ApiException">A server-side error occurred.</exception>
         public async Task<WalletAddress> GetWalletAddressAsync(
             string walletAddress,
             CancellationToken cancellationToken
@@ -139,6 +146,13 @@ namespace OpenPayments.Sdk.Generated.Wallet
             }
         }
 
+        /// <summary>
+        /// Retrieves the JSON Web Key Set (JWKS) bound to a wallet address.
+        /// </summary>
+        /// <param name="walletAddress">The absolute wallet address URL.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>The wallet address's public keys.</returns>
+        /// <exception cref="ApiException">A server-side error occurred.</exception>
         public async Task<JsonWebKeySet> GetWalletAddressKeysAsync(
             string walletAddress,
             CancellationToken cancellationToken

--- a/OpenPayments.Sdk/OpenPayments.Sdk.csproj
+++ b/OpenPayments.Sdk/OpenPayments.Sdk.csproj
@@ -8,6 +8,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>Interledger.OpenPayments</AssemblyName>
     <RootNamespace>Interledger.OpenPayments</RootNamespace>
     <RepositoryUrl>https://github.com/interledger/open-payments-dotnet</RepositoryUrl>

--- a/OpenPayments.Sdk/OpenPayments.Sdk.csproj
+++ b/OpenPayments.Sdk/OpenPayments.Sdk.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="NSec.Cryptography" Version="25.4.0"/>
     <ProjectReference Include="..\OpenPayments.Sdk.HttpSignatureUtils\OpenPayments.Sdk.HttpSignatureUtils.csproj" />
     <None Include="../LICENSE" Pack="true" PackagePath=""/>
-    <None Include="../README.md" Pack="true" PackagePath=""/>
+    <None Include="README.md" Pack="true" PackagePath=""/>
     <None Update="icon.png">
       <Pack>True</Pack>
       <PackagePath></PackagePath>

--- a/OpenPayments.Sdk/OpenPayments.Sdk.csproj
+++ b/OpenPayments.Sdk/OpenPayments.Sdk.csproj
@@ -8,7 +8,6 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>1591</NoWarn>
     <AssemblyName>Interledger.OpenPayments</AssemblyName>
     <RootNamespace>Interledger.OpenPayments</RootNamespace>
     <RepositoryUrl>https://github.com/interledger/open-payments-dotnet</RepositoryUrl>

--- a/OpenPayments.Sdk/README.md
+++ b/OpenPayments.Sdk/README.md
@@ -1,0 +1,69 @@
+# Open Payments .NET SDK
+
+.NET SDK for [Open Payments](https://openpayments.dev/), an open API standard implemented by account
+servicing entities (banks, digital wallet providers, mobile money providers) to enable interoperable setup
+and completion of payments — one-time payments, recurring remittances, tipping, and more.
+
+## Supported frameworks
+
+Targets `net9.0`. For HTTP Message Signatures usable standalone on `net8.0`, see
+[`Interledger.OpenPayments.HttpSignatureUtils`](https://www.nuget.org/packages/Interledger.OpenPayments.HttpSignatureUtils),
+which this package depends on.
+
+## Install
+
+```bash
+dotnet add package Interledger.OpenPayments
+```
+
+## Quickstart
+
+Register the SDK with dependency injection, then resolve an `IAuthenticatedClient`:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using OpenPayments.Sdk.Clients;
+using OpenPayments.Sdk.Extensions;
+using OpenPayments.Sdk.HttpSignatureUtils;
+
+var client = new ServiceCollection()
+    .UseOpenPayments(opts =>
+    {
+        opts.UseAuthenticatedClient = true;
+        opts.KeyId = CLIENT_ID;
+        opts.PrivateKey = KeyUtils.LoadPem(CLIENT_SECRET);
+        opts.ClientUrl = new Uri(CLIENT_WALLET_ADDRESS);
+    })
+    .BuildServiceProvider()
+    .GetRequiredService<IAuthenticatedClient>();
+
+var walletAddress = await client.GetWalletAddressAsync("https://wallet.example/alice");
+```
+
+For complete end-to-end flows — one-time payments, recurring remittances, grant continuation, and more —
+see the runnable guides in
+[`OpenPayments.Snippets/Guides`](https://github.com/interledger/open-payments-dotnet/tree/main/OpenPayments.Snippets/Guides).
+
+## Error handling
+
+Generated client methods throw `ApiException` — or its generic subtype `ApiException<TResult>` — when the
+server returns an unexpected status code. `ApiException` carries the response `StatusCode`, `Response`
+body, and `Headers`. A distinct `ApiException` type exists per generated namespace
+(`OpenPayments.Sdk.Generated.Auth`, `OpenPayments.Sdk.Generated.Resource`,
+`OpenPayments.Sdk.Generated.Wallet`), since each is generated independently from its own OpenAPI spec.
+
+The unauthenticated client's `GetIncomingPaymentAsync` throws `InvalidOperationException` if the server
+responds successfully but returns an empty or unparsable body.
+
+A unified exception type that wraps all of the above into a single public type is planned for a future
+release.
+
+## Versioning
+
+This package follows [Semantic Versioning](https://semver.org/). See the project's
+[GitHub Releases](https://github.com/interledger/open-payments-dotnet/releases) for change history —
+release notes are generated automatically from merged pull requests.
+
+## Learn more
+
+Visit [openpayments.dev](https://openpayments.dev/sdk/before-you-begin/) for a detailed guide.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 [![Status](https://img.shields.io/badge/status-active-success.svg)]()
-[![GitHub Issues](https://img.shields.io/github/issues/interledger/open-payments-dotnet.svg)](https://github.com/kylelobo/open-payments-dotnet/issues)
+[![GitHub Issues](https://img.shields.io/github/issues/interledger/open-payments-dotnet.svg)](https://github.com/interledger/open-payments-dotnet/issues)
 [![GitHub Pull Requests](https://img.shields.io/github/issues-pr/interledger/open-payments-dotnet.svg)](https://github.com/interledger/open-payments-dotnet/pulls)
 
 ## What is Open Payments?
@@ -65,7 +65,7 @@ git submodule update --init
 Alternatively, clone the repository with submodules in one step:
 
 ```bash
-git clone --recurse-submodules git@github.com:interledger/open-payments-node.git
+git clone --recurse-submodules git@github.com:interledger/open-payments-dotnet.git
 ```
 
 ### Prerequisites
@@ -96,35 +96,16 @@ dotnet test
 
 ## 🎈 Usage
 
-To use in your project, just add the package using the command line
+This repository publishes two NuGet packages, each with its own install/quickstart instructions:
 
-```bash
-dotnet add package Interledger.OpenPayments
-```
+- [`Interledger.OpenPayments`](OpenPayments.Sdk/README.md) — the main SDK: authenticated/unauthenticated
+  clients for the wallet address, resource, and authorization servers.
+- [`Interledger.OpenPayments.HttpSignatureUtils`](OpenPayments.Sdk.HttpSignatureUtils/README.md) — HTTP
+  Message Signatures (RFC 9421), usable standalone.
 
-Then add it to your project code
-
-```csharp
-// Import dependencies
-using Microsoft.Extensions.DependencyInjection;
-using OpenPayments.Sdk.Clients;
-using OpenPayments.Sdk.Extensions;
-using OpenPayments.Sdk.HttpSignatureUtils;
-
-// Initialize client
-var client = new ServiceCollection()
-    .UseOpenPayments(opts =>
-    {
-        opts.UseAuthenticatedClient = true;
-        opts.KeyId = CLIENT_ID;
-        opts.PrivateKey = KeyUtils.LoadPem(CLIENT_SECRET);
-        opts.ClientUrl = new Uri(CLIENT_WALLET_ADDRESS);
-    })
-    .BuildServiceProvider()
-    .GetRequiredService<IAuthenticatedClient>();
-```
-
-Please visit [OpenPayments Docs](https://openpayments.dev/sdk/before-you-begin/) for a detailed guide.
+For complete end-to-end flows, see the runnable guides in
+[`OpenPayments.Snippets/Guides`](OpenPayments.Snippets/Guides), or visit
+[openpayments.dev](https://openpayments.dev/sdk/before-you-begin/) for a detailed guide.
 
 ## ✍️ Authors
 


### PR DESCRIPTION
## Summary
- Closes every CS1591 (missing XML doc) warning in `OpenPayments.Sdk` by hand-documenting all real (non-generated) public members, and scopes suppression to only the NSwag-generated model files via a targeted `.editorconfig`
- Enables `TreatWarningsAsErrors` on both `OpenPayments.Sdk` and `OpenPayments.Sdk.HttpSignatureUtils` so future undocumented members fail CI instead of silently shipping
- Adds NuGet packaging metadata and a dedicated `README.md` to each published package (`Interledger.OpenPayments`, `Interledger.OpenPayments.HttpSignatureUtils`), replacing the shared root README as the packed content
- Fixes stale links in the root `README.md` and points its Usage section at the new package READMEs instead of duplicating content

## Test plan
- [x] `dotnet build OpenPayments.Sdk/OpenPayments.Sdk.csproj -c Release` — 0 Warning(s), 0 Error(s)
- [x] `dotnet build OpenPayments.Sdk.HttpSignatureUtils/OpenPayments.Sdk.HttpSignatureUtils.csproj -c Release` — 0 Warning(s), 0 Error(s)
- [x] `dotnet build -c Release` (whole solution) — 0 Warning(s), 0 Error(s)
- [x] `dotnet test` — 63/63 passing
- [x] `dotnet pack` both library projects — both nupkgs build and bundle their own `README.md`
- [x] Every README code block checked against real, compiling source
- [x] Independent final whole-branch review (all 13 task-level reviews + one cross-cutting pass) — clean