### PR TITLE
fix(httpsig): require content-digest when request body present

### DIFF
--- a/OpenPayments.Sdk.HttpSignatureUtils.Tests/HttpSignatureValidator_ValidateSignatureAsync_Tests.cs
+++ b/OpenPayments.Sdk.HttpSignatureUtils.Tests/HttpSignatureValidator_ValidateSignatureAsync_Tests.cs
@@ -1,0 +1,107 @@
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using NSec.Cryptography;
+using OpenPayments.Sdk.HttpSignatureUtils;
+using Xunit;
+
+namespace OpenPayments.Sdk.HttpSignatureUtils.Tests;
+
+public class HttpSignatureValidator_ValidateSignatureAsync_Tests
+{
+    private static HttpSignatureValidator CreateValidator() =>
+        new(new SignatureInputParser(), new SignatureInputValidator(), new SignatureInputBuilder());
+
+    private static (Key key, Jwk jwk) CreateKeyPair(string keyId = "test-key")
+    {
+        var key = KeyUtils.GenerateKey();
+        var jwk = KeyUtils.GenerateJwk(keyId, key);
+        return (key, jwk);
+    }
+
+    private static async Task AttachSignatureAsync(
+        HttpRequestMessage request,
+        Key privateKey,
+        string keyId
+    )
+    {
+        var headers = await HttpRequestSigner.SignHttpRequestAsync(request, privateKey, keyId);
+        request.Headers.TryAddWithoutValidation("Signature", headers.Signature);
+        request.Headers.TryAddWithoutValidation("Signature-Input", headers.SignatureInput);
+    }
+
+    [Fact]
+    public async Task ValidateSignatureAsync_AcceptsMatchingBodyAndDigest()
+    {
+        var (key, jwk) = CreateKeyPair();
+        var body = """{"amount":"1"}""";
+        var request = new HttpRequestMessage(HttpMethod.Post, "https://example.com/pay")
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
+        };
+        await AttachSignatureAsync(request, key, "test-key");
+
+        var ok = await CreateValidator().ValidateSignatureAsync(request, jwk);
+        Assert.True(ok);
+    }
+
+    [Fact]
+    public async Task ValidateSignatureAsync_RejectsBodySwapUnderStaleContentDigest()
+    {
+        var (key, jwk) = CreateKeyPair();
+        var originalBody = """{"amount":"1"}""";
+        var request = new HttpRequestMessage(HttpMethod.Post, "https://example.com/pay")
+        {
+            Content = new StringContent(originalBody, Encoding.UTF8, "application/json"),
+        };
+        await AttachSignatureAsync(request, key, "test-key");
+
+        var staleDigest = request.Content!.Headers.GetValues("Content-Digest").First();
+        var signature = request.Headers.GetValues("Signature").First();
+        var signatureInput = request.Headers.GetValues("Signature-Input").First();
+
+        // Swap body but keep Signature, Signature-Input, and original Content-Digest.
+        // Ed25519 over the signature base still verifies; digest-vs-body must fail closed.
+        var swapped = new HttpRequestMessage(HttpMethod.Post, "https://example.com/pay")
+        {
+            Content = new StringContent(
+                """{"amount":"999999"}""",
+                Encoding.UTF8,
+                "application/json"
+            ),
+        };
+        swapped.Content.Headers.TryAddWithoutValidation("Content-Digest", staleDigest);
+        swapped.Headers.TryAddWithoutValidation("Signature", signature);
+        swapped.Headers.TryAddWithoutValidation("Signature-Input", signatureInput);
+
+        var ok = await CreateValidator().ValidateSignatureAsync(swapped, jwk);
+        Assert.False(ok);
+    }
+
+    [Fact]
+    public async Task ContentDigest_MatchesRequest_RejectsTamperedBody()
+    {
+        var body = """{"amount":"1"}""";
+        var request = new HttpRequestMessage(HttpMethod.Post, "https://example.com/pay")
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
+        };
+        request.Content.Headers.TryAddWithoutValidation(
+            "Content-Digest",
+            ContentDigest.ForBody(body)
+        );
+        Assert.True(await ContentDigest.MatchesRequestAsync(request));
+
+        request.Content = new StringContent(
+            """{"amount":"2"}""",
+            Encoding.UTF8,
+            "application/json"
+        );
+        request.Content.Headers.TryAddWithoutValidation(
+            "Content-Digest",
+            ContentDigest.ForBody(body)
+        );
+        Assert.False(await ContentDigest.MatchesRequestAsync(request));
+    }
+}

--- a/OpenPayments.Sdk.HttpSignatureUtils.Tests/SignatureInputValidator_Validate_Tests.cs
+++ b/OpenPayments.Sdk.HttpSignatureUtils.Tests/SignatureInputValidator_Validate_Tests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Net.Http;
 using OpenPayments.Sdk.HttpSignatureUtils;
 using Xunit;
 

--- a/OpenPayments.Sdk.HttpSignatureUtils.Tests/SignatureInputValidator_Validate_Tests.cs
+++ b/OpenPayments.Sdk.HttpSignatureUtils.Tests/SignatureInputValidator_Validate_Tests.cs
@@ -1,0 +1,70 @@
+using OpenPayments.Sdk.HttpSignatureUtils;
+using Xunit;
+
+namespace OpenPayments.Sdk.HttpSignatureUtils.Tests;
+
+public class SignatureInputValidator_Validate_Tests
+{
+    private readonly SignatureInputValidator _validator = new();
+
+    [Fact]
+    public void Validate_RejectsMissingContentDigestCoverageWhenBodyPresent()
+    {
+        var body = """{"amount":"1"}""";
+        var request = new HttpRequestMessage(HttpMethod.Post, "https://example.com/resource")
+        {
+            Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json"),
+        };
+        request.Content.Headers.ContentLength = body.Length;
+
+        // Cover method/target/type but omit content-digest despite body.
+        var components = new List<string> { "@method", "@target-uri", "content-type" };
+
+        Assert.False(_validator.Validate(components, request));
+    }
+
+    [Fact]
+    public void Validate_AcceptsContentDigestCoverageWhenBodyPresent()
+    {
+        var body = """{"amount":"1"}""";
+        var request = new HttpRequestMessage(HttpMethod.Post, "https://example.com/resource")
+        {
+            Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json"),
+        };
+        request.Content.Headers.TryAddWithoutValidation(
+            "Content-Digest",
+            "sha-512=:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==:"
+        );
+        // StringContent already sets Content-Type; ensure Content-Length is present.
+        request.Content.Headers.ContentLength = body.Length;
+
+        var components = new List<string>
+        {
+            "@method",
+            "@target-uri",
+            "content-digest",
+            "content-length",
+            "content-type",
+        };
+
+        Assert.True(_validator.Validate(components, request));
+    }
+
+    [Fact]
+    public void Validate_AllowsMissingContentDigestWhenNoBody()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, "https://example.com/resource");
+        var components = new List<string> { "@method", "@target-uri" };
+
+        Assert.True(_validator.Validate(components, request));
+    }
+
+    [Fact]
+    public void Validate_RejectsNonLowercaseComponents()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, "https://example.com/resource");
+        var components = new List<string> { "@METHOD", "@target-uri" };
+
+        Assert.False(_validator.Validate(components, request));
+    }
+}

--- a/OpenPayments.Sdk.HttpSignatureUtils/ContentDigest.cs
+++ b/OpenPayments.Sdk.HttpSignatureUtils/ContentDigest.cs
@@ -1,0 +1,35 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace OpenPayments.Sdk.HttpSignatureUtils;
+
+/// <summary>
+/// Open Payments Content-Digest helpers (sha-512, RFC 9530 structured field).
+/// </summary>
+internal static class ContentDigest
+{
+    public static string ForBody(string body)
+    {
+        var hash = SHA512.HashData(Encoding.UTF8.GetBytes(body));
+        return $"sha-512=:{Convert.ToBase64String(hash)}:";
+    }
+
+    public static async Task<bool> MatchesRequestAsync(HttpRequestMessage request)
+    {
+        if (request.Content is null)
+            return false;
+
+        string? digestHeader = null;
+        if (request.Content.Headers.TryGetValues("Content-Digest", out var contentValues))
+            digestHeader = contentValues.FirstOrDefault();
+        else if (request.Headers.TryGetValues("Content-Digest", out var values))
+            digestHeader = values.FirstOrDefault();
+
+        if (string.IsNullOrEmpty(digestHeader))
+            return false;
+
+        var body = await request.Content.ReadAsStringAsync();
+        var expected = ForBody(body);
+        return string.Equals(expected, digestHeader, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/OpenPayments.Sdk.HttpSignatureUtils/HttpSignatureValidator.cs
+++ b/OpenPayments.Sdk.HttpSignatureUtils/HttpSignatureValidator.cs
@@ -41,6 +41,15 @@ public class HttpSignatureValidator : IHttpSignatureValidator
         if (!_validator.Validate(components, request))
             return false;
 
+        // Open Payments / GNAP: when content-digest is covered, the header MUST match
+        // the request body (parity with open-payments-go / rust). Signature verification
+        // alone does not bind the body if Content-Digest is stale after a swap.
+        if (
+            components.Contains("content-digest")
+            && !await ContentDigest.MatchesRequestAsync(request)
+        )
+            return false;
+
         var challenge = await _builder.BuildBaseAsync(components, request, sigInput);
         if (challenge is null)
             return false;

--- a/OpenPayments.Sdk.HttpSignatureUtils/SignatureInputBuilder.cs
+++ b/OpenPayments.Sdk.HttpSignatureUtils/SignatureInputBuilder.cs
@@ -1,5 +1,5 @@
-using System.Security.Cryptography;
 using System.Text;
+using OpenPayments.Sdk.HttpSignatureUtils;
 
 /// <inheritdoc cref="ISignatureInputBuilder"/>
 public class SignatureInputBuilder : ISignatureInputBuilder
@@ -18,7 +18,8 @@ public class SignatureInputBuilder : ISignatureInputBuilder
             switch (component)
             {
                 case "@method":
-                    sb.AppendLine($"\"@method\": {request.Method.Method.ToLower()}");
+                    // RFC 9421: @method is case-normalized to uppercase (matches HttpRequestSigner).
+                    sb.AppendLine($"\"@method\": {request.Method.Method.ToUpperInvariant()}");
                     break;
                 case "@target-uri":
                     sb.AppendLine($"\"@target-uri\": {request.RequestUri}");
@@ -44,8 +45,7 @@ public class SignatureInputBuilder : ISignatureInputBuilder
         if (name == "content-digest" && request.Content != null)
         {
             var body = await request.Content.ReadAsStringAsync();
-            var hash = SHA256.HashData(Encoding.UTF8.GetBytes(body));
-            return $"sha-256=:{Convert.ToBase64String(hash)}:";
+            return ContentDigest.ForBody(body);
         }
 
         return "";

--- a/OpenPayments.Sdk.HttpSignatureUtils/SignatureInputValidator.cs
+++ b/OpenPayments.Sdk.HttpSignatureUtils/SignatureInputValidator.cs
@@ -6,7 +6,8 @@ public class SignatureInputValidator : ISignatureInputValidator
     /// <inheritdoc cref="ISignatureInputValidator"/>
     public bool Validate(List<string> components, HttpRequestMessage request)
     {
-        if (components.Any(c => !c.Equals(c, StringComparison.CurrentCultureIgnoreCase)))
+        // Open Payments / HTTP Message Signatures: component names are lowercase.
+        if (components.Any(c => c != c.ToLowerInvariant()))
             return false;
 
         var hasMethod = components.Contains("@method");
@@ -14,13 +15,33 @@ public class SignatureInputValidator : ISignatureInputValidator
         var hasAuth =
             !request.Headers.Contains("Authorization") || components.Contains("authorization");
 
+        // Open Payments / GNAP: when a request body is present, content-digest MUST be
+        // covered (parity with open-payments-go / node / php / rust). Previously
+        // `!components.Contains("content-digest") || …` treated omission as success.
+        var hasBody = RequestHasBody(request);
         var hasDigest =
-            !components.Contains("content-digest")
-            || request.Content != null
-            && request.Content.Headers.Contains("Content-Digest")
-            && request.Content.Headers.Contains("Content-Length")
-            && request.Content.Headers.Contains("Content-Type");
+            !hasBody
+            || (
+                components.Contains("content-digest")
+                && request.Content != null
+                && request.Content.Headers.Contains("Content-Digest")
+                && request.Content.Headers.Contains("Content-Length")
+                && request.Content.Headers.Contains("Content-Type")
+            );
 
         return hasMethod && hasTargetUri && hasAuth && hasDigest;
+    }
+
+    private static bool RequestHasBody(HttpRequestMessage request)
+    {
+        if (request.Content is null)
+            return false;
+
+        if (request.Content.Headers.ContentLength is long len)
+            return len > 0;
+
+        // Content present without an explicit length: treat as a body so digest
+        // coverage cannot be skipped by omitting Content-Length.
+        return true;
     }
 }


### PR DESCRIPTION
## Summary
Hardens Open Payments HTTP signature validation for request bodies (parity with [open-payments-go#50](https://github.com/interledger/open-payments-go/pull/50), [open-payments-node#38](https://github.com/interledger/open-payments-node/pull/38), [open-payments-php#9](https://github.com/interledger/open-payments-php/pull/9), [open-payments-rust#34](https://github.com/interledger/open-payments-rust/pull/34)):

1. **`SignatureInputValidator`:** previously treated missing `content-digest` coverage as success (`!components.Contains("content-digest") || …`). Now requires `content-digest` (+ Content-Digest / Length / Type headers) when a body is present. Also fixes the lowercase-component check (prior `c.Equals(c, IgnoreCase)` was a no-op).
2. **`HttpSignatureValidator`:** verifies `sha-512` Content-Digest against the request body when `content-digest` is covered, so a body swap under a stale digest + still-valid Ed25519 signature fails closed.
3. **`SignatureInputBuilder`:** aligns `@method` (uppercase per RFC 9421) and content-digest fallback (`sha-512`) with `HttpRequestSigner`.

## Test plan
- [x] `dotnet test OpenPayments.Sdk.HttpSignatureUtils.Tests` → 36/36
- [ ] Upstream Actions (fork PR currently `action_required` pending maintainer workflow approval)